### PR TITLE
Fix to permit brackets inside labels

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -149,7 +149,7 @@ export default class InlineCalloutsPlugin extends Plugin {
 		const beforeCursor = curLine.slice(0, curCh);
 		const afterCursor = curLine.slice(curCh);
 
-		const matcher = { type: ContextType.INLINECODE, regex: /`(\[!![^`]+\])`/g, enable: true }
+		const matcher = { type: ContextType.INLINECODE, regex: /^`(\[!![^`]+\])`$/, enable: true }
 		const matchInfo = this.getMatchInfo(beforeCursor, afterCursor, matcher.regex);
 
 		if (matchInfo) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -187,7 +187,7 @@ export default class InlineCalloutsPlugin extends Plugin {
 		const beforeCursor = curLine.slice(0, curCh);
 		const afterCursor = curLine.slice(curCh);
 
-		const matcher = { type: ContextType.INLINECODE, regex: /`(\[!![^`]+\])`/g, enable: true }
+		const matcher = { type: ContextType.INLINECODE, regex: /^`(\[!![^`]+\])`$/, enable: true }
 		const matchInfo = this.getMatchInfo(beforeCursor, afterCursor, matcher.regex);
 
 		if (matchInfo) {


### PR DESCRIPTION
Forcing global recognition with ^ and $, and removing g flag, the label can contain square brackets.